### PR TITLE
added new linter rules for screenshots

### DIFF
--- a/custom_otello_linter/abstract_checkers/get_full_func_name.py
+++ b/custom_otello_linter/abstract_checkers/get_full_func_name.py
@@ -1,0 +1,15 @@
+import ast
+
+
+def get_full_func_name(func_node) -> str:
+    """
+    Извлекает полное имя функции из узла ast.Call.func.
+    Для прямых вызовов (make_screenshot_for_comparison) возвращает 'make_screenshot_for_comparison'.
+    Для вызовов через атрибуты (self.page.make_screenshot_for_comparison)
+    возвращает 'self.page.make_screenshot_for_comparison'.
+    """
+    if isinstance(func_node, ast.Name):
+        return func_node.id
+    elif isinstance(func_node, ast.Attribute):
+        return get_full_func_name(func_node.value) + '.' + func_node.attr
+    return ""

--- a/custom_otello_linter/abstract_checkers/scenario_helper.py
+++ b/custom_otello_linter/abstract_checkers/scenario_helper.py
@@ -1,5 +1,5 @@
 import ast
-from typing import List
+from typing import List, Union
 
 SCENARIOS_FOLDER = 'scenarios'
 
@@ -13,3 +13,27 @@ class ScenarioHelper:
                 or isinstance(element, ast.AsyncFunctionDef)
             )
         ]
+
+    # Метод находит узел с декоратором и списком лейблов
+    def get_allure_decorator(self, scenario_node: ast.ClassDef) -> Union[ast.Call, None]:
+        for decorator in scenario_node.decorator_list:
+            if isinstance(decorator, ast.Call) and isinstance(decorator.func, ast.Name):
+                if decorator.func.id == 'allure_labels':
+                    return decorator
+
+    # Метод получает список тегов из переданного декоратора @allure_labels
+    def get_allure_tag_names(self, allure_decorator: ast.Call) -> List[str]:
+
+        def get_tag_first_name(arg: ast.Attribute) -> str:
+            if isinstance(arg.value, ast.Attribute):
+                return get_tag_first_name(arg.value)
+            if isinstance(arg.value, ast.Name):
+                return arg.value.id
+
+        tags_names = []
+        for arg in allure_decorator.args:
+            if isinstance(arg, ast.Attribute):
+                tags_names.append(get_tag_first_name(arg))
+            elif isinstance(arg, ast.Name):
+                tags_names.append(arg.id)
+        return tags_names

--- a/custom_otello_linter/errors/__init__.py
+++ b/custom_otello_linter/errors/__init__.py
@@ -1,4 +1,6 @@
 from .errors import (
     DecoratorVedroParams,
+    MissingAllureScreenshotsLabelError,
+    MissingMakeScreenshotFuncCallError,
     MultipleScreenshotsError
 )

--- a/custom_otello_linter/errors/errors.py
+++ b/custom_otello_linter/errors/errors.py
@@ -9,3 +9,13 @@ class DecoratorVedroParams(Error):
 class MultipleScreenshotsError(Error):
     code = 'OCS300'
     message = 'step "{step_name}" make_screenshot_for_comparison is used more than once'
+
+
+class MissingAllureScreenshotsLabelError(Error):
+    code = 'SCR001'
+    message = 'Test contains "make_screenshot_for_comparison" but is missing label "SCREENSHOTS".'
+
+
+class MissingMakeScreenshotFuncCallError(Error):
+    code = 'SRC002'
+    message = 'Test is marked with label "SCREENSHOTS" but doesnt contain "make_screenshot_for_comparison" call.'

--- a/custom_otello_linter/plugins.py
+++ b/custom_otello_linter/plugins.py
@@ -35,7 +35,7 @@ class PluginWithFilename(Plugin):
 
 class OtelloQAStylePlugin(PluginWithFilename):
     name = 'custom_otello_linter'
-    version = '1.0.2'
+    version = '1.0.3'
     visitors = [
         ScenarioVisitor,
     ]

--- a/custom_otello_linter/rules/SCR001.md
+++ b/custom_otello_linter/rules/SCR001.md
@@ -1,0 +1,30 @@
+# SCR001. Missing "SCREENSHOTS" allure label when using "make_screenshot_for_comparison"
+Test must be labeled with the "SCREENSHOTS" allure label if it contains a call to "make_screenshot_for_comparison"
+### ❌ Anti-pattern
+****
+```python
+@allure_labels(MANUAL, PRIORITY.P0) <- "SCREENSHOTS" label is missed
+class Scenario:
+    subject = "Open main page"
+    
+    def when_opened_main_page(self):
+        self.page = opened_main_page()
+        
+    def then_page_should_be_visible(self):
+        self.page.make_screenshot_for_comparison()
+
+```
+
+### ✅ Best practice
+
+```python
+@allure_labels(MANUAL, PRIORITY.P0, SCREENSHOTS)
+class Scenario:
+    subject = "Open main page"
+    
+    def when_opened_main_page(self):
+        self.page = opened_main_page()
+        
+    def then_page_should_be_visible(self):
+        self.page.make_screenshot_for_comparison()
+```

--- a/custom_otello_linter/rules/SCR002.md
+++ b/custom_otello_linter/rules/SCR002.md
@@ -1,0 +1,31 @@
+# SRC002. Missing "make_screenshot_for_comparison" call when using "SCREENSHOTS" label
+Test must contain a call "to make_screenshot_for_comparison" if it is labeled with the "SCREENSHOTS" allure label.
+### ❌ Anti-pattern
+****
+```python
+@allure_labels(SCREENSHOTS)
+class Scenario:
+    subject = "Open main page"
+    
+    def when_opened_main_page(self):
+        self.page = opened_main_page()
+        
+    def then_main_element_is_visible(self): 
+        self.page.main_element.is_visible() 
+                                            <- a call to "make_screenshot_for_comparison" is missed
+```
+
+### ✅ Best practice
+
+```python
+@allure_labels(SCREENSHOTS)
+class Scenario:
+    subject = "Open main page"
+    
+    def when_opened_main_page(self):
+        self.page = opened_main_page()
+        
+    def then_main_element_is_visible(self):
+        self.page.main_element.is_visible() 
+        self.page.make_screenshot_for_comparison()
+```

--- a/custom_otello_linter/visitors/__init__.py
+++ b/custom_otello_linter/visitors/__init__.py
@@ -1,7 +1,4 @@
-from .scenario_checkers import (
-    VedroParamsChecker
-)
+from .scenario_checkers import VedroParamsChecker
 from .scenario_visitor import Context, ScenarioVisitor
-from .steps_checkers import (
-    MakeScreenshotChecker,
-)
+from .screenshot_label_and_func_checker import ScreenshotsLabelAndFuncChecker
+from .steps_checkers import MakeScreenshotChecker

--- a/custom_otello_linter/visitors/scenario_checkers/decorator_vedro_params_checker.py
+++ b/custom_otello_linter/visitors/scenario_checkers/decorator_vedro_params_checker.py
@@ -5,7 +5,10 @@ from flake8_plugin_utils import Error
 
 from custom_otello_linter.abstract_checkers import ScenarioChecker
 from custom_otello_linter.errors import DecoratorVedroParams
-from custom_otello_linter.visitors.scenario_visitor import Context, ScenarioVisitor
+from custom_otello_linter.visitors.scenario_visitor import (
+    Context,
+    ScenarioVisitor
+)
 
 
 @ScenarioVisitor.register_scenario_checker

--- a/custom_otello_linter/visitors/scenario_visitor.py
+++ b/custom_otello_linter/visitors/scenario_visitor.py
@@ -8,7 +8,9 @@ from custom_otello_linter.abstract_checkers import (
 )
 from custom_otello_linter.config import Config
 from custom_otello_linter.types import FuncType
-from custom_otello_linter.visitors._visitor_with_filename import VisitorWithFilename
+from custom_otello_linter.visitors._visitor_with_filename import (
+    VisitorWithFilename
+)
 
 
 class Context:

--- a/custom_otello_linter/visitors/screenshot_label_and_func_checker.py
+++ b/custom_otello_linter/visitors/screenshot_label_and_func_checker.py
@@ -1,0 +1,54 @@
+import ast
+from typing import List
+
+from flake8_plugin_utils import Error
+
+from custom_otello_linter.abstract_checkers import StepsChecker
+from custom_otello_linter.abstract_checkers.get_full_func_name import (
+    get_full_func_name
+)
+from custom_otello_linter.errors import (
+    MissingAllureScreenshotsLabelError,
+    MissingMakeScreenshotFuncCallError
+)
+from custom_otello_linter.visitors.scenario_visitor import (
+    Context,
+    ScenarioVisitor
+)
+
+
+@ScenarioVisitor.register_steps_checker
+class ScreenshotsLabelAndFuncChecker(StepsChecker):
+
+    def check_steps(self, context: Context, config) -> List[Error]:
+        errors = []
+
+        allure_decorator = self.get_allure_decorator(context.scenario_node)
+        has_screenshot_label = False
+        has_screenshot_func = False
+
+        if allure_decorator:
+            allure_tags = self.get_allure_tag_names(allure_decorator)
+            has_screenshot_label = "SCREENSHOTS" in allure_tags
+
+        for step in context.steps:
+            for stmt in step.body:
+                for node in ast.walk(stmt):
+                    if isinstance(node, ast.Call):
+                        func_name = get_full_func_name(node.func)
+                        print(f"Found function call: {func_name}")
+                        if func_name.endswith("make_screenshot_for_comparison"):
+                            has_screenshot_func = True
+                            break
+
+        if has_screenshot_label and not has_screenshot_func:
+            errors.append(MissingMakeScreenshotFuncCallError(
+                lineno=context.scenario_node.lineno,
+                col_offset=context.scenario_node.col_offset))
+
+        if has_screenshot_func and not has_screenshot_label:
+            errors.append(MissingAllureScreenshotsLabelError(
+                lineno=allure_decorator.lineno,
+                col_offset=allure_decorator.col_offset))
+
+        return errors

--- a/custom_otello_linter/visitors/screenshot_label_and_func_checker.py
+++ b/custom_otello_linter/visitors/screenshot_label_and_func_checker.py
@@ -27,28 +27,32 @@ class ScreenshotsLabelAndFuncChecker(StepsChecker):
         has_screenshot_label = False
         has_screenshot_func = False
 
+        # Проверяем, есть ли в списке лейблов SCREENSHOTS
         if allure_decorator:
             allure_tags = self.get_allure_tag_names(allure_decorator)
             has_screenshot_label = "SCREENSHOTS" in allure_tags
 
+        # Проверяем наличие вызова функции make_screenshot_for_comparison
         for step in context.steps:
             for stmt in step.body:
                 for node in ast.walk(stmt):
                     if isinstance(node, ast.Call):
                         func_name = get_full_func_name(node.func)
-                        print(f"Found function call: {func_name}")
                         if func_name.endswith("make_screenshot_for_comparison"):
                             has_screenshot_func = True
                             break
 
+        # Если в тесте есть лейбл, но нет вызова функции – добавляем ошибку
         if has_screenshot_label and not has_screenshot_func:
             errors.append(MissingMakeScreenshotFuncCallError(
                 lineno=context.scenario_node.lineno,
                 col_offset=context.scenario_node.col_offset))
 
+        # Если в тесте есть вызов функции, но нет лейбла – добавляем ошибку
         if has_screenshot_func and not has_screenshot_label:
             errors.append(MissingAllureScreenshotsLabelError(
                 lineno=allure_decorator.lineno,
                 col_offset=allure_decorator.col_offset))
 
+        # Возвращаем собранные ошибки после завершения всех шагов
         return errors

--- a/custom_otello_linter/visitors/steps_checkers/make_screenshot_checker.py
+++ b/custom_otello_linter/visitors/steps_checkers/make_screenshot_checker.py
@@ -4,8 +4,14 @@ from typing import List
 from flake8_plugin_utils import Error
 
 from custom_otello_linter.abstract_checkers import StepsChecker
+from custom_otello_linter.abstract_checkers.get_full_func_name import (
+    get_full_func_name
+)
 from custom_otello_linter.errors import MultipleScreenshotsError
-from custom_otello_linter.visitors.scenario_visitor import Context, ScenarioVisitor
+from custom_otello_linter.visitors.scenario_visitor import (
+    Context,
+    ScenarioVisitor
+)
 
 
 @ScenarioVisitor.register_steps_checker
@@ -28,7 +34,7 @@ class MakeScreenshotChecker(StepsChecker):
                     # Применяем ast.walk к каждому выражению в теле функции
                     for node in ast.walk(stmt):
                         if isinstance(node, ast.Call):
-                            func_name = self._get_full_func_name(node.func)
+                            func_name = get_full_func_name(node.func)
 
                             # Проверяем вызов функции make_screenshot_for_comparison
                             if func_name.endswith('make_screenshot_for_comparison'):
@@ -46,16 +52,3 @@ class MakeScreenshotChecker(StepsChecker):
 
         # Возвращаем собранные ошибки после завершения всех шагов
         return errors
-
-    def _get_full_func_name(self, func_node) -> str:
-        """
-        Извлекает полное имя функции из узла ast.Call.func.
-        Для прямых вызовов (make_screenshot_for_comparison) возвращает 'make_screenshot_for_comparison'.
-        Для вызовов через атрибуты (self.page.make_screenshot_for_comparison)
-        возвращает 'self.page.make_screenshot_for_comparison'.
-        """
-        if isinstance(func_node, ast.Name):
-            return func_node.id
-        elif isinstance(func_node, ast.Attribute):
-            return self._get_full_func_name(func_node.value) + '.' + func_node.attr
-        return ""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = custom_otello_linter
-version = 1.0.2
+version = 1.0.3
 
 [options.entry_points]
 flake8.extension =

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def find_dev_required():
 
 setup(
     name="custom-otello-linter",
-    version="1.0.2",
+    version="1.0.3",
     description="flake8 based linter for frontend tests",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/test_assert.py
+++ b/tests/test_assert.py
@@ -1,8 +1,6 @@
 from flake8_plugin_utils import assert_error, assert_not_error
 
-from custom_otello_linter.errors import (
-    MultipleScreenshotsError
-)
+from custom_otello_linter.errors import MultipleScreenshotsError
 from custom_otello_linter.visitors import ScenarioVisitor
 from custom_otello_linter.visitors.steps_checkers import MakeScreenshotChecker
 
@@ -58,7 +56,7 @@ def test_two_func_make_screenshot_in_step_and():
     assert_error(ScenarioVisitor, code, MultipleScreenshotsError, step_name='and_')
 
 
-def test_otwo_func_make_screenshot_in_step_but():
+def test_two_func_make_screenshot_in_step_but():
     ScenarioVisitor.deregister_all()
     ScenarioVisitor.register_steps_checker(MakeScreenshotChecker)
     code = """

--- a/tests/test_screenshot_label_and_func.py
+++ b/tests/test_screenshot_label_and_func.py
@@ -1,0 +1,84 @@
+from flake8_plugin_utils import assert_error, assert_not_error
+
+from custom_otello_linter.errors import (
+    MissingAllureScreenshotsLabelError,
+    MissingMakeScreenshotFuncCallError
+)
+from custom_otello_linter.visitors import ScenarioVisitor
+from custom_otello_linter.visitors.screenshot_label_and_func_checker import (
+    ScreenshotsLabelAndFuncChecker
+)
+
+
+def test_screenshot_label_with_make_screenshot_func():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_steps_checker(ScreenshotsLabelAndFuncChecker)
+    code = """
+    @allure_labels(SCREENSHOTS)
+    class Scenario:
+        def when(): pass
+        def then():
+            photos.make_screenshot_for_comparison()
+    """
+    assert_not_error(ScenarioVisitor, code)
+
+
+def test_screenshot_label_without_make_screenshot_func():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_steps_checker(ScreenshotsLabelAndFuncChecker)
+    code = """
+    @allure_labels(SCREENSHOTS)
+    class Scenario:
+        def when(): pass
+        def then(): pass
+    """
+    assert_error(ScenarioVisitor, code, MissingMakeScreenshotFuncCallError)
+
+
+def test_make_screenshot_func_without_screenshots_label():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_steps_checker(ScreenshotsLabelAndFuncChecker)
+    code = """
+    @allure_labels(MANUAL, Priority.P0)
+    class Scenario:
+        def when(): pass
+        def then():
+            self.page.make_screenshot_for_comparison()
+    """
+    assert_error(ScenarioVisitor, code, MissingAllureScreenshotsLabelError)
+
+
+def test_other_labels_without_make_screenshot_func():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_steps_checker(ScreenshotsLabelAndFuncChecker)
+    code = """
+    @allure_labels(MANUAL, Feature.One)
+    class Scenario:
+        def when(): pass
+        def then(): pass
+    """
+    assert_not_error(ScenarioVisitor, code)
+
+
+def test_multiple_labels_with_make_screenshot_func():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_steps_checker(ScreenshotsLabelAndFuncChecker)
+    code = """
+    @allure_labels(MANUAL, Feature.One, SCREENSHOTS)
+    class Scenario:
+        def when(): pass
+        def then():
+            self.page.make_screenshot_for_comparison()
+    """
+    assert_not_error(ScenarioVisitor, code)
+
+
+def test_no_labels_no_make_screenshot_func():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_steps_checker(ScreenshotsLabelAndFuncChecker)
+    code = """
+    class Scenario:
+        def when(): pass
+        def then(): pass
+    """
+    assert_not_error(ScenarioVisitor, code)


### PR DESCRIPTION
Added a new linter rule that will check:

1. If test has the "SCREENSHOTS" label, it must include a call to the "make_screenshot_for_comparison()" function.

2. If test includes a call to the "make_screenshot_for_comparison()" function, it must have the "SCREENSHOTS" label.