### PR TITLE
Add platform in subject linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ ignore = OCS101
 ### Scenario Rules
 1. [OCS101. Decorator @vedro.params should not be presented](./custom_otello_linter/rules/OCS101.md)
 2. [OCS102. Missing "SCREENSHOTS" allure label when using "make_screenshot_for_comparison"](./custom_otello_linter/rules/OCS102.md)
-3. [OCS103. Subject must contain platform](./custom_otello_linter/rules/OCS103.md)
-4. [OCS104. Platform in subject must correspond to the platform in allure labels](./custom_otello_linter/rules/OCS104.md)
+3. [OCS103. Missing platform in subject: must contain one of platform from dicts.platforms in (platform_from_dicts) or ({{platform}}) placeholder](./custom_otello_linter/rules/OCS103.md)
+4. [OCS104. Invalid platform in subject: platform in subject must be placed in the end of the subject and be one of dicts.platforms in (platform_from_dicts) or ({{platform}}) placeholder](./custom_otello_linter/rules/OCS104.md)
+5. [OCS105. Platform in subject doesn`t match platform in allure labels](./custom_otello_linter/rules/OCS105.md)
 
 ###  Scenario Steps Rules
 1. [OCS300. Function make_screenshot used once](./custom_otello_linter/rules/OCS300.md)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ ignore = OCS101
 ### Scenario Rules
 1. [OCS101. Decorator @vedro.params should not be presented](./custom_otello_linter/rules/OCS101.md)
 2. [OCS102. Missing "SCREENSHOTS" allure label when using "make_screenshot_for_comparison"](./custom_otello_linter/rules/OCS102.md)
+3. [OCS103. Subject must contain platform](./custom_otello_linter/rules/OCS103.md)
+4. [OCS104. Platform in subject must correspond to the platform in allure labels](./custom_otello_linter/rules/OCS104.md)
 
 ###  Scenario Steps Rules
 1. [OCS300. Function make_screenshot used once](./custom_otello_linter/rules/OCS300.md)

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ ignore = OCS101
 ### Scenario Rules
 1. [OCS101. Decorator @vedro.params should not be presented](./custom_otello_linter/rules/OCS101.md)
 2. [OCS102. Missing "SCREENSHOTS" allure label when using "make_screenshot_for_comparison"](./custom_otello_linter/rules/OCS102.md)
-3. [OCS103. Missing platform in subject: must contain one of platform from dicts.platforms in (platform_from_dicts) or ({{platform}}) placeholder](./custom_otello_linter/rules/OCS103.md)
-4. [OCS104. Invalid platform in subject: platform in subject must be placed in the end of the subject and be one of dicts.platforms in (platform_from_dicts) or ({{platform}}) placeholder](./custom_otello_linter/rules/OCS104.md)
+3. [OCS103. Missing platform in subject: must contain one of platform from dicts.platforms as (platform) or ({{platform}}) placeholder](./custom_otello_linter/rules/OCS103.md)
+4. [OCS104. Invalid platform in subject: platform in subject must be placed in the end of the subject and be one of dicts.platforms as (platform) or ({{platform}}) placeholder](./custom_otello_linter/rules/OCS104.md)
 5. [OCS105. Platform in subject doesn`t match platform in allure labels](./custom_otello_linter/rules/OCS105.md)
 
 ###  Scenario Steps Rules

--- a/custom_otello_linter/dicts/platforms.py
+++ b/custom_otello_linter/dicts/platforms.py
@@ -1,6 +1,6 @@
 class Platforms:
 
-    LABEL_TO_SUBJECT_PLATFORM = {
+    ALLURE_PLATFORM_TO_SUBJECT_PLATFORM = {
         "MOBILE": "mobile",
         "IOS_WEB_MOBILE": "ios web",
         "ANDROID_WEB_MOBILE": "android web",

--- a/custom_otello_linter/dicts/platforms.py
+++ b/custom_otello_linter/dicts/platforms.py
@@ -1,0 +1,12 @@
+class Platforms:
+
+    LABEL_TO_SUBJECT_PLATFORM = {
+        "MOBILE": "mobile",
+        "IOS_WEB_MOBILE": "ios web",
+        "ANDROID_WEB_MOBILE": "android web",
+        "DESKTOP": "desktop",
+        "MOBILE_APP": "mobile app",
+        "ANDROID_MOBILE_APP": "android mobile app",
+        "IOS_MOBILE_APP": "ios mobile app",
+        "SBOL": "SBOL",
+    }

--- a/custom_otello_linter/dicts/platforms.py
+++ b/custom_otello_linter/dicts/platforms.py
@@ -1,6 +1,6 @@
 class Platforms:
 
-    ALLURE_PLATFORM_TO_SUBJECT_PLATFORM = {
+    ALLURE_TO_SUBJECT_PLATFORM = {
         "MOBILE": "mobile",
         "IOS_WEB_MOBILE": "ios web",
         "ANDROID_WEB_MOBILE": "android web",

--- a/custom_otello_linter/errors/__init__.py
+++ b/custom_otello_linter/errors/__init__.py
@@ -4,6 +4,7 @@ from .errors import (
     MissingScreenshotsAllureLabelError,
     MissingPlatformInSubjectError,
     InvalidPlatformInSubjectError,
+    NotMatchingPlatformInSubjectError,
     MultipleScreenshotsError,
     MissingPlatformArgError
 )

--- a/custom_otello_linter/errors/__init__.py
+++ b/custom_otello_linter/errors/__init__.py
@@ -2,6 +2,8 @@ from .errors import (
     DecoratorVedroParams,
     MissingMakeScreenshotFuncCallError,
     MissingScreenshotsAllureLabelError,
+    MissingPlatformInSubjectError,
+    InvalidPlatformInSubjectError,
     MultipleScreenshotsError,
     MissingPlatformArgError
 )

--- a/custom_otello_linter/errors/errors.py
+++ b/custom_otello_linter/errors/errors.py
@@ -31,7 +31,7 @@ class MissingPlatformArgError(Error):
 
 class MissingPlatformInSubjectError(Error):
     code = "OCS103"
-    message = 'subject must contain platform or ({platform}) placeholder'
+    message = 'subject must contain platform or ({{platform}}) placeholder'
 
 
 class InvalidPlatformInSubjectError(Error):

--- a/custom_otello_linter/errors/errors.py
+++ b/custom_otello_linter/errors/errors.py
@@ -31,9 +31,16 @@ class MissingPlatformArgError(Error):
 
 class MissingPlatformInSubjectError(Error):
     code = "OCS103"
-    message = 'subject must contain platform or ({{platform}}) placeholder'
+    message = ('missing platform in subject: must contain one of platform from dicts.platforms in (platform_from_dicts)'
+               'or ({{platform}}) placeholder')
 
 
 class InvalidPlatformInSubjectError(Error):
     code = "OCS104"
-    message = 'platform in subject must correspond to the platform in allure labels'
+    message = ('invalid platform in subject: platform in subject must be placed in the end of the subject '
+               'and be one of dicts.platforms in (platform_from_dicts) or ({{platform}}) placeholder')
+
+
+class NotMatchingPlatformInSubjectError(Error):
+    code = "OCS105"
+    message = 'platform in subject doesn`t match platform in allure labels'

--- a/custom_otello_linter/errors/errors.py
+++ b/custom_otello_linter/errors/errors.py
@@ -27,3 +27,13 @@ class MissingMakeScreenshotFuncCallError(Error):
 class MissingPlatformArgError(Error):
     code = 'OCS302'
     message = 'test is missing "platform" argument in page opening context call'
+
+
+class MissingPlatformInSubjectError(Error):
+    code = "OCS103"
+    message = 'subject must contain one of platform from dicts/platforms.py'
+
+
+class InvalidPlatformInSubjectError(Error):
+    code = "OCS104"
+    message = 'platform in subject must correspond to the platform in allure labels'

--- a/custom_otello_linter/errors/errors.py
+++ b/custom_otello_linter/errors/errors.py
@@ -31,7 +31,7 @@ class MissingPlatformArgError(Error):
 
 class MissingPlatformInSubjectError(Error):
     code = "OCS103"
-    message = 'subject must contain one of platform from dicts/platforms.py'
+    message = 'subject must contain platform or ({platform}) placeholder'
 
 
 class InvalidPlatformInSubjectError(Error):

--- a/custom_otello_linter/errors/errors.py
+++ b/custom_otello_linter/errors/errors.py
@@ -31,14 +31,14 @@ class MissingPlatformArgError(Error):
 
 class MissingPlatformInSubjectError(Error):
     code = "OCS103"
-    message = ('missing platform in subject: must contain one of platform from dicts.platforms in (platform_from_dicts)'
+    message = ('missing platform in subject: must contain one of platform from dicts.platforms as (platform)'
                'or ({{platform}}) placeholder')
 
 
 class InvalidPlatformInSubjectError(Error):
     code = "OCS104"
     message = ('invalid platform in subject: platform in subject must be placed in the end of the subject '
-               'and be one of dicts.platforms in (platform_from_dicts) or ({{platform}}) placeholder')
+               'and be one of dicts.platforms as (platform) or ({{platform}}) placeholder')
 
 
 class NotMatchingPlatformInSubjectError(Error):

--- a/custom_otello_linter/helpers/get_subject.py
+++ b/custom_otello_linter/helpers/get_subject.py
@@ -1,0 +1,14 @@
+import ast
+from typing import Optional, Tuple
+
+
+def get_subject(scenario_node: ast.ClassDef) -> Tuple[Optional[str], Optional[ast.Assign]]:
+    for node in scenario_node.body:
+        if isinstance(node, ast.Assign):
+            has_subject_target = any(
+                isinstance(target, ast.Name) and target.id == "subject"
+                for target in node.targets
+            )
+            if has_subject_target and isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                return node.value.value, node
+    return None, None

--- a/custom_otello_linter/helpers/get_subject.py
+++ b/custom_otello_linter/helpers/get_subject.py
@@ -3,6 +3,10 @@ from typing import Optional, Tuple
 
 
 def get_subject(scenario_node: ast.ClassDef) -> Tuple[Optional[str], Optional[ast.Assign]]:
+    """
+    Возвращает строковое значение атрибута `subject` и ast узел присваивания в классе сценария
+    Если `subject` отсутствует или не является строкой возвращает (None, None)
+    """
     for node in scenario_node.body:
         if isinstance(node, ast.Assign):
             has_subject_target = any(

--- a/custom_otello_linter/plugins.py
+++ b/custom_otello_linter/plugins.py
@@ -35,7 +35,7 @@ class PluginWithFilename(Plugin):
 
 class OtelloQAStylePlugin(PluginWithFilename):
     name = 'custom_otello_linter'
-    version = '1.0.5'
+    version = '1.0.6'
     visitors = [
         ScenarioVisitor,
     ]

--- a/custom_otello_linter/rules/OCS103.md
+++ b/custom_otello_linter/rules/OCS103.md
@@ -1,0 +1,29 @@
+# OCS103. subject must contain one of platform from dicts/platforms.py
+Subject of a scenario always must contain platform from project's dicts.
+
+### ❌ Anti-pattern
+```python
+class Scenario:
+    subject = "Open checkout"
+
+    def when_user_open_checkout(self):
+        pass
+```
+```python
+@allure_labels(Platform.MOBILE)
+    class Scenario:
+        subject = "Open checkout"
+
+        def when_user_open_checkout(self):
+            pass
+```
+
+### ✅ Best practice
+```python
+@allure_labels(Platform.MOBILE)
+class Scenario:
+    subject = "Open checkout (mobile)"
+
+    def when_user_open_checkout(self):
+        pass
+```

--- a/custom_otello_linter/rules/OCS103.md
+++ b/custom_otello_linter/rules/OCS103.md
@@ -1,10 +1,17 @@
-# OCS103. Subject must contain platform or ({platform}) placeholder
+# OCS103. Missing platform in subject: must contain one of platform from dicts.platforms in (platform_from_dicts) or ({{platform}}) placeholder
 Subject of a scenario always must contain platform. It can be either explicitly (e.g. "Open checkout (mobile)") or implicitly (e.g. "Open checkout ({platform})") if the scenario is parametrized with platforms.
 
 ### ❌ Anti-pattern
 ```python
 class Scenario:
     subject = "Open checkout"
+
+    def when_user_open_checkout(self):
+        pass
+```
+```python
+class Scenario:
+    subject = "Open checkout mobile_app"
 
     def when_user_open_checkout(self):
         pass
@@ -26,4 +33,14 @@ class Scenario:
 
     def when_user_open_checkout(self):
         pass
+```
+```python
+@allure_labels(Feature.AI_ASSISTANT, Story.HOTEL_CARD, Priority.P0)
+class Scenario(vedro.Scenario):
+    subject = 'Swipe photo gallery widget in ai chat ({platform})'
+
+    @params(Platforms.MOBILE)
+    @params(Platforms.MOBILE_APP)
+    def __init__(self, platform):
+        self.platform = platform
 ```

--- a/custom_otello_linter/rules/OCS103.md
+++ b/custom_otello_linter/rules/OCS103.md
@@ -1,5 +1,5 @@
-# OCS103. subject must contain one of platform from dicts/platforms.py
-Subject of a scenario always must contain platform from project's dicts.
+# OCS103. Subject must contain platform or ({platform}) placeholder
+Subject of a scenario always must contain platform. It can be either explicitly (e.g. "Open checkout (mobile)") or implicitly (e.g. "Open checkout ({platform})") if the scenario is parametrized with platforms.
 
 ### ❌ Anti-pattern
 ```python

--- a/custom_otello_linter/rules/OCS103.md
+++ b/custom_otello_linter/rules/OCS103.md
@@ -1,4 +1,4 @@
-# OCS103. Missing platform in subject: must contain one of platform from dicts.platforms in (platform_from_dicts) or ({{platform}}) placeholder
+# OCS103. Missing platform in subject: must contain one of platform from dicts.platforms as (platform) or ({{platform}}) placeholder
 Subject of a scenario always must contain platform. It can be either explicitly (e.g. "Open checkout (mobile)") or implicitly (e.g. "Open checkout ({platform})") if the scenario is parametrized with platforms.
 
 ### ❌ Anti-pattern

--- a/custom_otello_linter/rules/OCS104.md
+++ b/custom_otello_linter/rules/OCS104.md
@@ -1,11 +1,11 @@
-# OCS104. Platform in subject must correspond to the platform in allure labels
-Platform in subject of scenario must correspond to the platform in allure labels.
+# OCS104. Invalid platform in subject: platform in subject must be placed in the end of the subject and be one of dicts.platforms in (platform_from_dicts) or ({{platform}}) placeholder
+Subject of a scenario always must contain one of dicts.platforms in the end of it. It can be either explicitly (e.g. "Open checkout (mobile)") or implicitly (e.g. "Open checkout ({platform})") if the scenario is parametrized with platforms.
 
 ### ❌ Anti-pattern
 ```python
 @allure_labels(Platform.MOBILE)
     class Scenario:
-        subject = "Open checkout (desktop)"
+        subject = "Open checkout (web)"
 
         def when_user_open_checkout(self):
             pass
@@ -13,7 +13,15 @@ Platform in subject of scenario must correspond to the platform in allure labels
 ```python
 @allure_labels(Platform.MOBILE)
     class Scenario:
-        subject = "Open checkout ({platform})"
+        subject = "Open checkout (mobile) (as abroad user)"
+
+        def when_user_open_checkout(self):
+            pass
+```
+```python
+@allure_labels(Platform.MOBILE)
+    class Scenario:
+        subject = "Open checkout (as abroad user, mobile)"
 
         def when_user_open_checkout(self):
             pass
@@ -27,4 +35,28 @@ class Scenario:
 
     def when_user_open_checkout(self):
         pass
+```
+```python
+@allure_labels(Platform.MOBILE)
+    class Scenario:
+        subject = "Open checkout as abroad user (mobile)"
+
+        def when_user_open_checkout(self):
+            pass
+```
+```python
+@allure_labels(Platform.MOBILE)
+    class Scenario:
+        subject = "Open checkout: some details (mobile)"
+
+        def when_user_open_checkout(self):
+            pass
+```
+```python
+@allure_labels(Platform.MOBILE)
+    class Scenario:
+        subject = "Open checkout (some details) (mobile)"
+
+        def when_user_open_checkout(self):
+            pass
 ```

--- a/custom_otello_linter/rules/OCS104.md
+++ b/custom_otello_linter/rules/OCS104.md
@@ -1,4 +1,4 @@
-# OCS104. Invalid platform in subject: platform in subject must be placed in the end of the subject and be one of dicts.platforms in (platform_from_dicts) or ({{platform}}) placeholder
+# OCS104. Invalid platform in subject: platform in subject must be placed in the end of the subject and be one of dicts.platforms as (platform) or ({{platform}}) placeholder
 Subject of a scenario always must contain one of dicts.platforms in the end of it. It can be either explicitly (e.g. "Open checkout (mobile)") or implicitly (e.g. "Open checkout ({platform})") if the scenario is parametrized with platforms.
 
 ### ❌ Anti-pattern

--- a/custom_otello_linter/rules/OCS104.md
+++ b/custom_otello_linter/rules/OCS104.md
@@ -1,0 +1,30 @@
+# OCS104. Platform in subject must correspond to the platform in allure labels
+Platform in subject of scenario must correspond to the platform in allure labels.
+
+### ❌ Anti-pattern
+```python
+@allure_labels(Platform.MOBILE)
+    class Scenario:
+        subject = "Open checkout (desktop)"
+
+        def when_user_open_checkout(self):
+            pass
+```
+```python
+@allure_labels(Platform.MOBILE)
+    class Scenario:
+        subject = "Open checkout ({platform})"
+
+        def when_user_open_checkout(self):
+            pass
+```
+
+### ✅ Best practice
+```python
+@allure_labels(Platform.MOBILE)
+class Scenario:
+    subject = "Open checkout (mobile)"
+
+    def when_user_open_checkout(self):
+        pass
+```

--- a/custom_otello_linter/rules/OCS105.md
+++ b/custom_otello_linter/rules/OCS105.md
@@ -1,0 +1,30 @@
+# OCS105. Platform in subject doesn`t match platform in allure labels
+Platform in subject of scenario must match to the platform in allure labels.
+
+### ❌ Anti-pattern
+```python
+@allure_labels(Platform.MOBILE)
+    class Scenario:
+        subject = "Open checkout (desktop)"
+
+        def when_user_open_checkout(self):
+            pass
+```
+```python
+@allure_labels(Platform.MOBILE)
+    class Scenario:
+        subject = "Open checkout ({platform})"
+
+        def when_user_open_checkout(self):
+            pass
+```
+
+### ✅ Best practice
+```python
+@allure_labels(Platform.MOBILE)
+class Scenario:
+    subject = "Open checkout (mobile)"
+
+    def when_user_open_checkout(self):
+        pass
+```

--- a/custom_otello_linter/visitors/__init__.py
+++ b/custom_otello_linter/visitors/__init__.py
@@ -1,5 +1,5 @@
 from .scenario_and_steps_checkers import ScreenshotsLabelAndFuncChecker
-from .scenario_checkers import VedroParamsChecker
+from .scenario_checkers import VedroParamsChecker, SubjectChecker
 from .scenario_visitor import Context, ScenarioVisitor
 from .steps_checkers import MakeScreenshotChecker
 from .steps_checkers import PlatformParamsChecker

--- a/custom_otello_linter/visitors/scenario_checkers/__init__.py
+++ b/custom_otello_linter/visitors/scenario_checkers/__init__.py
@@ -1,1 +1,2 @@
 from .decorator_vedro_params_checker import VedroParamsChecker
+from .subject_checker import SubjectChecker

--- a/custom_otello_linter/visitors/scenario_checkers/subject_checker.py
+++ b/custom_otello_linter/visitors/scenario_checkers/subject_checker.py
@@ -28,8 +28,9 @@ class SubjectChecker(ScenarioChecker):
         subject_value, subject_node = get_subject(context.scenario_node)
 
         # ищем указание платформы в последних круглых скобках сабджекта
+        # заменяем _ на пробел, чтобы mobile app и mobile_app считались равными
         matches = re.findall(r"\(([^()]*)\)", subject_value)
-        subject_platform = matches[-1].strip() if matches else None
+        subject_platform = matches[-1].strip().replace("_", " ") if matches else None
         # проверяем, что платформа указана и она из заданного списка платформ
         if subject_platform not in allowed_platforms:
             return [MissingPlatformInSubjectError(

--- a/custom_otello_linter/visitors/scenario_checkers/subject_checker.py
+++ b/custom_otello_linter/visitors/scenario_checkers/subject_checker.py
@@ -27,15 +27,16 @@ class SubjectChecker(ScenarioChecker):
         allowed_platforms = set(self._LABEL_TO_SUBJECT_PLATFORM.values()) | {"{platform}"}
         subject_value, subject_node = get_subject(context.scenario_node)
 
+        # ищем указание платформы в последних круглых скобках сабджекта
         matches = re.findall(r"\(([^()]*)\)", subject_value)
         subject_platform = matches[-1].strip() if matches else None
-
+        # проверяем, что платформа указана и она из заданного списка платформ
         if subject_platform not in allowed_platforms:
             return [MissingPlatformInSubjectError(
                 lineno=subject_node.lineno,
                 col_offset=subject_node.col_offset
             )]
-
+        # проверяем, что платформа в subject соответствует указанной в allure_labels
         allure_platform, allure_platform_node = self._extract_allure_platform(context.scenario_node)
         if allure_platform is not None and subject_platform != allure_platform:
             node = allure_platform_node or subject_node
@@ -47,6 +48,11 @@ class SubjectChecker(ScenarioChecker):
         return []
 
     def _extract_allure_platform(self, scenario_node: ast.ClassDef) -> Tuple[Optional[str], Optional[ast.AST]]:
+        """
+        Ищет в декораторе @allure_labels указание платформы вида Platform.X.
+        Возвращает кортеж: (значение платформы для subject, AST-узел аргумента).
+        Если платформа не найдена, возвращает (None, None).
+        """
         allure_decorator = self.get_allure_labels_decorator(scenario_node)
         if not allure_decorator:
             return None, None

--- a/custom_otello_linter/visitors/scenario_checkers/subject_checker.py
+++ b/custom_otello_linter/visitors/scenario_checkers/subject_checker.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Tuple
 
 from flake8_plugin_utils import Error
 
+from custom_otello_linter.dicts.platforms import Platforms
 from custom_otello_linter.abstract_checkers import ScenarioChecker
 from custom_otello_linter.errors import (
     MissingPlatformInSubjectError,
@@ -16,20 +17,13 @@ from custom_otello_linter.helpers.get_subject import get_subject
 
 @ScenarioVisitor.register_scenario_checker
 class SubjectChecker(ScenarioChecker):
-    _LABEL_TO_SUBJECT_PLATFORM = {
-        "MOBILE": "mobile",
-        "IOS_WEB_MOBILE": "ios web",
-        "ANDROID_WEB_MOBILE": "android web",
-        "DESKTOP": "desktop",
-        "MOBILE_APP": "mobile app",
-        "ANDROID_MOBILE_APP": "android mobile app",
-        "IOS_MOBILE_APP": "ios mobile app",
-        "SBOL": "SBOL",
-    }
 
     def check_scenario(self, context: Context, config) -> List[Error]:
-        allowed_platforms = set(self._LABEL_TO_SUBJECT_PLATFORM.values()) | {"{platform}"}
+        allowed_platforms = set(Platforms.LABEL_TO_SUBJECT_PLATFORM.values()) | {"{platform}"}
         subject_value, subject_node = get_subject(context.scenario_node)
+        # на всякий случай игнорируем (наш фреймворк не позволяет запускать тесты без сабджекта)
+        if subject_value is None or subject_node is None:
+            return []
 
         # ищем указание платформы в последних круглых скобках сабджекта
         # заменяем _ на пробел, чтобы mobile app и mobile_app считались равными
@@ -72,8 +66,8 @@ class SubjectChecker(ScenarioChecker):
                 isinstance(arg, ast.Attribute)
                 and isinstance(arg.value, ast.Name)
                 and arg.value.id == "Platform"
-                and arg.attr in self._LABEL_TO_SUBJECT_PLATFORM
+                and arg.attr in Platforms.LABEL_TO_SUBJECT_PLATFORM
             ):
-                return self._LABEL_TO_SUBJECT_PLATFORM[arg.attr], arg
+                return Platforms.LABEL_TO_SUBJECT_PLATFORM[arg.attr], arg
 
         return None, None

--- a/custom_otello_linter/visitors/scenario_checkers/subject_checker.py
+++ b/custom_otello_linter/visitors/scenario_checkers/subject_checker.py
@@ -5,7 +5,11 @@ from typing import List, Optional, Tuple
 from flake8_plugin_utils import Error
 
 from custom_otello_linter.abstract_checkers import ScenarioChecker
-from custom_otello_linter.errors import MissingPlatformInSubjectError, InvalidPlatformInSubjectError
+from custom_otello_linter.errors import (
+    MissingPlatformInSubjectError,
+    NotMatchingPlatformInSubjectError,
+    InvalidPlatformInSubjectError
+)
 from custom_otello_linter.visitors.scenario_visitor import Context, ScenarioVisitor
 from custom_otello_linter.helpers.get_subject import get_subject
 
@@ -32,8 +36,13 @@ class SubjectChecker(ScenarioChecker):
         matches = re.findall(r"\(([^()]*)\)", subject_value)
         subject_platform = matches[-1].strip().replace("_", " ") if matches else None
         # проверяем, что платформа указана и она из заданного списка платформ
-        if subject_platform not in allowed_platforms:
+        if subject_platform is None:
             return [MissingPlatformInSubjectError(
+                lineno=subject_node.lineno,
+                col_offset=subject_node.col_offset
+            )]
+        if subject_platform not in allowed_platforms:
+            return [InvalidPlatformInSubjectError(
                 lineno=subject_node.lineno,
                 col_offset=subject_node.col_offset
             )]
@@ -41,7 +50,7 @@ class SubjectChecker(ScenarioChecker):
         allure_platform, allure_platform_node = self._extract_allure_platform(context.scenario_node)
         if allure_platform is not None and subject_platform != allure_platform:
             node = allure_platform_node or subject_node
-            return [InvalidPlatformInSubjectError(
+            return [NotMatchingPlatformInSubjectError(
                 lineno=node.lineno,
                 col_offset=node.col_offset
             )]

--- a/custom_otello_linter/visitors/scenario_checkers/subject_checker.py
+++ b/custom_otello_linter/visitors/scenario_checkers/subject_checker.py
@@ -14,12 +14,12 @@ from custom_otello_linter.helpers.get_subject import get_subject
 class SubjectChecker(ScenarioChecker):
     _LABEL_TO_SUBJECT_PLATFORM = {
         "MOBILE": "mobile",
-        "IOS_WEB_MOBILE": "ios_web_mobile",
-        "ANDROID_WEB_MOBILE": "android_web_mobile",
+        "IOS_WEB_MOBILE": "ios web",
+        "ANDROID_WEB_MOBILE": "android web",
         "DESKTOP": "desktop",
-        "MOBILE_APP": "mobile_app",
-        "ANDROID_MOBILE_APP": "android_mobile_app",
-        "IOS_MOBILE_APP": "ios_mobile_app",
+        "MOBILE_APP": "mobile app",
+        "ANDROID_MOBILE_APP": "android mobile app",
+        "IOS_MOBILE_APP": "ios mobile app",
         "SBOL": "SBOL",
     }
 

--- a/custom_otello_linter/visitors/scenario_checkers/subject_checker.py
+++ b/custom_otello_linter/visitors/scenario_checkers/subject_checker.py
@@ -18,24 +18,23 @@ from custom_otello_linter.helpers.get_subject import get_subject
 @ScenarioVisitor.register_scenario_checker
 class SubjectChecker(ScenarioChecker):
 
+    _ALLOWED_PLATFORMS = (set(Platforms.ALLURE_PLATFORM_TO_SUBJECT_PLATFORM.values()) | {"{platform}"})
+
     def check_scenario(self, context: Context, config) -> List[Error]:
-        allowed_platforms = set(Platforms.LABEL_TO_SUBJECT_PLATFORM.values()) | {"{platform}"}
         subject_value, subject_node = get_subject(context.scenario_node)
         # на всякий случай игнорируем (наш фреймворк не позволяет запускать тесты без сабджекта)
         if subject_value is None or subject_node is None:
             return []
 
         # ищем указание платформы в последних круглых скобках сабджекта
-        # заменяем _ на пробел, чтобы mobile app и mobile_app считались равными
-        matches = re.findall(r"\(([^()]*)\)", subject_value)
-        subject_platform = matches[-1].strip().replace("_", " ") if matches else None
+        subject_platform = self._extract_subject_platform(subject_value)
         # проверяем, что платформа указана и она из заданного списка платформ
         if subject_platform is None:
             return [MissingPlatformInSubjectError(
                 lineno=subject_node.lineno,
                 col_offset=subject_node.col_offset
             )]
-        if subject_platform not in allowed_platforms:
+        if subject_platform not in self._ALLOWED_PLATFORMS:
             return [InvalidPlatformInSubjectError(
                 lineno=subject_node.lineno,
                 col_offset=subject_node.col_offset
@@ -66,8 +65,21 @@ class SubjectChecker(ScenarioChecker):
                 isinstance(arg, ast.Attribute)
                 and isinstance(arg.value, ast.Name)
                 and arg.value.id == "Platform"
-                and arg.attr in Platforms.LABEL_TO_SUBJECT_PLATFORM
+                and arg.attr in Platforms.ALLURE_PLATFORM_TO_SUBJECT_PLATFORM
             ):
-                return Platforms.LABEL_TO_SUBJECT_PLATFORM[arg.attr], arg
+                return Platforms.ALLURE_PLATFORM_TO_SUBJECT_PLATFORM[arg.attr], arg
 
         return None, None
+
+    def _extract_subject_platform(self, subject_value: str) -> Optional[str]:
+        """
+        Извлекает платформу из последних круглых скобок в subject
+        Возвращает нормализованное значение (заменяет "_" на пробел, чтобы mobile app и mobile_app считались равными)
+        или None, если скобок в subject нет
+        """
+        matches = re.findall(r"\(([^()]*)\)", subject_value)
+        if not matches:
+            return None
+
+        last_parens = matches[-1].strip()
+        return last_parens.replace("_", " ")

--- a/custom_otello_linter/visitors/scenario_checkers/subject_checker.py
+++ b/custom_otello_linter/visitors/scenario_checkers/subject_checker.py
@@ -18,7 +18,7 @@ from custom_otello_linter.helpers.get_subject import get_subject
 @ScenarioVisitor.register_scenario_checker
 class SubjectChecker(ScenarioChecker):
 
-    _ALLOWED_PLATFORMS = (set(Platforms.ALLURE_PLATFORM_TO_SUBJECT_PLATFORM.values()) | {"{platform}"})
+    _ALLOWED_PLATFORMS = (set(Platforms.ALLURE_TO_SUBJECT_PLATFORM.values()) | {"{platform}"})
 
     def check_scenario(self, context: Context, config) -> List[Error]:
         subject_value, subject_node = get_subject(context.scenario_node)
@@ -65,9 +65,9 @@ class SubjectChecker(ScenarioChecker):
                 isinstance(arg, ast.Attribute)
                 and isinstance(arg.value, ast.Name)
                 and arg.value.id == "Platform"
-                and arg.attr in Platforms.ALLURE_PLATFORM_TO_SUBJECT_PLATFORM
+                and arg.attr in Platforms.ALLURE_TO_SUBJECT_PLATFORM
             ):
-                return Platforms.ALLURE_PLATFORM_TO_SUBJECT_PLATFORM[arg.attr], arg
+                return Platforms.ALLURE_TO_SUBJECT_PLATFORM[arg.attr], arg
 
         return None, None
 
@@ -77,9 +77,8 @@ class SubjectChecker(ScenarioChecker):
         Возвращает нормализованное значение (заменяет "_" на пробел, чтобы mobile app и mobile_app считались равными)
         или None, если скобок в subject нет
         """
-        matches = re.findall(r"\(([^()]*)\)", subject_value)
-        if not matches:
+        match = re.search(r".*\(([^()]*)\)", subject_value)
+        if not match:
             return None
 
-        last_parens = matches[-1].strip()
-        return last_parens.replace("_", " ")
+        return match.group(1).strip().replace("_", " ")

--- a/custom_otello_linter/visitors/scenario_checkers/subject_checker.py
+++ b/custom_otello_linter/visitors/scenario_checkers/subject_checker.py
@@ -1,0 +1,63 @@
+import ast
+import re
+from typing import List, Optional, Tuple
+
+from flake8_plugin_utils import Error
+
+from custom_otello_linter.abstract_checkers import ScenarioChecker
+from custom_otello_linter.errors import MissingPlatformInSubjectError, InvalidPlatformInSubjectError
+from custom_otello_linter.visitors.scenario_visitor import Context, ScenarioVisitor
+from custom_otello_linter.helpers.get_subject import get_subject
+
+
+@ScenarioVisitor.register_scenario_checker
+class SubjectChecker(ScenarioChecker):
+    _LABEL_TO_SUBJECT_PLATFORM = {
+        "MOBILE": "mobile",
+        "IOS_WEB_MOBILE": "ios_web_mobile",
+        "ANDROID_WEB_MOBILE": "android_web_mobile",
+        "DESKTOP": "desktop",
+        "MOBILE_APP": "mobile_app",
+        "ANDROID_MOBILE_APP": "android_mobile_app",
+        "IOS_MOBILE_APP": "ios_mobile_app",
+        "SBOL": "SBOL",
+    }
+
+    def check_scenario(self, context: Context, config) -> List[Error]:
+        allowed_platforms = set(self._LABEL_TO_SUBJECT_PLATFORM.values()) | {"{platform}"}
+        subject_value, subject_node = get_subject(context.scenario_node)
+
+        matches = re.findall(r"\(([^()]*)\)", subject_value)
+        subject_platform = matches[-1].strip() if matches else None
+
+        if subject_platform not in allowed_platforms:
+            return [MissingPlatformInSubjectError(
+                lineno=subject_node.lineno,
+                col_offset=subject_node.col_offset
+            )]
+
+        allure_platform, allure_platform_node = self._extract_allure_platform(context.scenario_node)
+        if allure_platform is not None and subject_platform != allure_platform:
+            node = allure_platform_node or subject_node
+            return [InvalidPlatformInSubjectError(
+                lineno=node.lineno,
+                col_offset=node.col_offset
+            )]
+
+        return []
+
+    def _extract_allure_platform(self, scenario_node: ast.ClassDef) -> Tuple[Optional[str], Optional[ast.AST]]:
+        allure_decorator = self.get_allure_labels_decorator(scenario_node)
+        if not allure_decorator:
+            return None, None
+
+        for arg in allure_decorator.args:
+            if (
+                isinstance(arg, ast.Attribute)
+                and isinstance(arg.value, ast.Name)
+                and arg.value.id == "Platform"
+                and arg.attr in self._LABEL_TO_SUBJECT_PLATFORM
+            ):
+                return self._LABEL_TO_SUBJECT_PLATFORM[arg.attr], arg
+
+        return None, None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-isort
+isort==5.12.0
 pytest>=7.2,<8
 mypy==1.0.0
 astpretty

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-isort==5.12.0
+isort
 pytest>=7.2,<8
 mypy==1.0.0
 astpretty

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = custom_otello_linter
-version = 1.0.5
+version = 1.0.6
 
 [options.entry_points]
 flake8.extension =

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def find_dev_required():
 
 setup(
     name="custom-otello-linter",
-    version="1.0.5",
+    version="1.0.6",
     description="flake8 based linter for frontend tests",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/test_subject_platform.py
+++ b/tests/test_subject_platform.py
@@ -63,6 +63,18 @@ def test_subject_with_long_platform_without_underscore():
     assert_not_error(ScenarioVisitor, code)
 
 
+def test_subject_with_several_parentheses():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(SubjectChecker)
+    code = """
+    class Scenario:
+        subject = "Open checkout (as abroad user) (mobile_app)"
+
+        def when_user_open_checkout(self):
+            pass
+    """
+    assert_not_error(ScenarioVisitor, code)
+
 
 def test_subject_without_platform():
     ScenarioVisitor.deregister_all()
@@ -70,6 +82,19 @@ def test_subject_without_platform():
     code = """
     class Scenario:
         subject = "Open checkout"
+
+        def when_user_open_checkout(self):
+            pass
+    """
+    assert_error(ScenarioVisitor, code, MissingPlatformInSubjectError)
+
+
+def test_subject_platform_without_parentheses():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(SubjectChecker)
+    code = """
+    class Scenario:
+        subject = "Open checkout android_mobile_app"
 
         def when_user_open_checkout(self):
             pass

--- a/tests/test_subject_platform.py
+++ b/tests/test_subject_platform.py
@@ -1,0 +1,115 @@
+from flake8_plugin_utils import assert_error, assert_not_error
+
+from custom_otello_linter.errors import MissingPlatformInSubjectError, InvalidPlatformInSubjectError
+from custom_otello_linter.visitors import ScenarioVisitor
+from custom_otello_linter.visitors.scenario_checkers.subject_checker import (
+    SubjectChecker,
+)
+
+
+def test_subject_with_platform_placeholder():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(SubjectChecker)
+    code = """
+    class Scenario:
+        subject = "Open checkout ({platform})"
+
+        def when_user_open_checkout(self):
+            pass
+    """
+    assert_not_error(ScenarioVisitor, code)
+
+
+def test_subject_with_concrete_allowed_platform():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(SubjectChecker)
+    code = """
+    class Scenario:
+        subject = "Open checkout (mobile)"
+
+        def when_user_open_checkout(self):
+            pass
+    """
+    assert_not_error(ScenarioVisitor, code)
+
+
+def test_subject_without_platform_in_parentheses():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(SubjectChecker)
+    code = """
+    class Scenario:
+        subject = "Open checkout"
+
+        def when_user_open_checkout(self):
+            pass
+    """
+    assert_error(ScenarioVisitor, code, MissingPlatformInSubjectError)
+
+
+def test_subject_with_unknown_platform():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(SubjectChecker)
+    code = """
+    class Scenario:
+        subject = "Open checkout (web)"
+
+        def when_user_open_checkout(self):
+            pass
+    """
+    assert_error(ScenarioVisitor, code, MissingPlatformInSubjectError)
+
+
+def test_allure_platform_matches_subject_platform():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(SubjectChecker)
+    code = """
+    @allure_labels(Platform.MOBILE)
+    class Scenario:
+        subject = "Open checkout (mobile)"
+
+        def when_user_open_checkout(self):
+            pass
+    """
+    assert_not_error(ScenarioVisitor, code)
+
+
+def test_allure_platform_mismatch_subject_platform():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(SubjectChecker)
+    code = """
+    @allure_labels(Platform.MOBILE)
+    class Scenario:
+        subject = "Open checkout (desktop)"
+
+        def when_user_open_checkout(self):
+            pass
+    """
+    assert_error(ScenarioVisitor, code, InvalidPlatformInSubjectError)
+
+
+def test_allure_platform_with_subject_placeholder_is_invalid():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(SubjectChecker)
+    code = """
+    @allure_labels(Platform.MOBILE)
+    class Scenario:
+        subject = "Open checkout ({platform})"
+
+        def when_user_open_checkout(self):
+            pass
+    """
+    assert_error(ScenarioVisitor, code, InvalidPlatformInSubjectError)
+
+
+def test_only_allure_platform():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(SubjectChecker)
+    code = """
+    @allure_labels(Platform.MOBILE)
+    class Scenario:
+        subject = "Open checkout"
+
+        def when_user_open_checkout(self):
+            pass
+    """
+    assert_error(ScenarioVisitor, code, MissingPlatformInSubjectError)

--- a/tests/test_subject_platform.py
+++ b/tests/test_subject_platform.py
@@ -33,6 +33,19 @@ def test_subject_with_concrete_allowed_platform():
     assert_not_error(ScenarioVisitor, code)
 
 
+def test_subject_with_underscore_platform():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(SubjectChecker)
+    code = """
+    class Scenario:
+        subject = "Open checkout (mobile_app)"
+
+        def when_user_open_checkout(self):
+            pass
+    """
+    assert_not_error(ScenarioVisitor, code)
+
+
 def test_subject_without_platform():
     ScenarioVisitor.deregister_all()
     ScenarioVisitor.register_scenario_checker(SubjectChecker)

--- a/tests/test_subject_platform.py
+++ b/tests/test_subject_platform.py
@@ -1,6 +1,10 @@
 from flake8_plugin_utils import assert_error, assert_not_error
 
-from custom_otello_linter.errors import MissingPlatformInSubjectError, InvalidPlatformInSubjectError
+from custom_otello_linter.errors import (
+    MissingPlatformInSubjectError,
+    NotMatchingPlatformInSubjectError,
+    InvalidPlatformInSubjectError
+)
 from custom_otello_linter.visitors import ScenarioVisitor
 from custom_otello_linter.visitors.scenario_checkers.subject_checker import (
     SubjectChecker,
@@ -46,6 +50,20 @@ def test_subject_with_underscore_platform():
     assert_not_error(ScenarioVisitor, code)
 
 
+def test_subject_with_long_platform_without_underscore():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(SubjectChecker)
+    code = """
+    class Scenario:
+        subject = "Open checkout (android mobile app)"
+
+        def when_user_open_checkout(self):
+            pass
+    """
+    assert_not_error(ScenarioVisitor, code)
+
+
+
 def test_subject_without_platform():
     ScenarioVisitor.deregister_all()
     ScenarioVisitor.register_scenario_checker(SubjectChecker)
@@ -69,7 +87,46 @@ def test_subject_with_unknown_platform():
         def when_user_open_checkout(self):
             pass
     """
-    assert_error(ScenarioVisitor, code, MissingPlatformInSubjectError)
+    assert_error(ScenarioVisitor, code, InvalidPlatformInSubjectError)
+
+
+def test_subject_with_not_right_placed_platform():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(SubjectChecker)
+    code = """
+    class Scenario:
+        subject = "Open checkout (mobile_app) (as abroad user)"
+
+        def when_user_open_checkout(self):
+            pass
+    """
+    assert_error(ScenarioVisitor, code, InvalidPlatformInSubjectError)
+
+
+def test_subject_with_not_lowercase_platform():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(SubjectChecker)
+    code = """
+    class Scenario:
+        subject = "Open checkout (Mobile)"
+
+        def when_user_open_checkout(self):
+            pass
+    """
+    assert_error(ScenarioVisitor, code, InvalidPlatformInSubjectError)
+
+
+def test_subject_with_platform_without_spaces():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(SubjectChecker)
+    code = """
+    class Scenario:
+        subject = "Open checkout (mobileapp)"
+
+        def when_user_open_checkout(self):
+            pass
+    """
+    assert_error(ScenarioVisitor, code, InvalidPlatformInSubjectError)
 
 
 def test_allure_platform_matches_subject_platform():
@@ -97,7 +154,7 @@ def test_allure_platform_mismatch_subject_platform():
         def when_user_open_checkout(self):
             pass
     """
-    assert_error(ScenarioVisitor, code, InvalidPlatformInSubjectError)
+    assert_error(ScenarioVisitor, code, NotMatchingPlatformInSubjectError)
 
 
 def test_allure_platform_with_subject_placeholder_is_invalid():
@@ -111,7 +168,7 @@ def test_allure_platform_with_subject_placeholder_is_invalid():
         def when_user_open_checkout(self):
             pass
     """
-    assert_error(ScenarioVisitor, code, InvalidPlatformInSubjectError)
+    assert_error(ScenarioVisitor, code, NotMatchingPlatformInSubjectError)
 
 
 def test_only_allure_platform():

--- a/tests/test_subject_platform.py
+++ b/tests/test_subject_platform.py
@@ -33,7 +33,7 @@ def test_subject_with_concrete_allowed_platform():
     assert_not_error(ScenarioVisitor, code)
 
 
-def test_subject_without_platform_in_parentheses():
+def test_subject_without_platform():
     ScenarioVisitor.deregister_all()
     ScenarioVisitor.register_scenario_checker(SubjectChecker)
     code = """
@@ -113,3 +113,17 @@ def test_only_allure_platform():
             pass
     """
     assert_error(ScenarioVisitor, code, MissingPlatformInSubjectError)
+
+
+def test_several_allure_labels_and_platform_matches_subject_platform():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(SubjectChecker)
+    code = """
+    @allure_labels(Feature.HOTEL, Story.HOTEL_CARD, Platform.MOBILE, Priority.P0)
+    class Scenario:
+        subject = "Open checkout (mobile)"
+
+        def when_user_open_checkout(self):
+            pass
+    """
+    assert_not_error(ScenarioVisitor, code)


### PR DESCRIPTION
Добавляем линтер на проверку указания платформы в сабжекте и проверку соответствия платформы в сабжекте указанной в аллюр лейблах платформе.
Проверяем по списку платформ в константе.

У платформы из сабжекта меняем нижние подчеркивания на пробелы, чтобы допускать и названия android mobile app, android_mobile_app. Показалось, будет непонятно если разрешать только с нижними подчеркиваниями или только без них, но если хотим разрешить какой-то один вид - я за вариант с подчеркиваниями, чтобы из dicts можно было спокойно скопипастить платформу